### PR TITLE
bgpd, zebra: Creating Loopback Interface Flaps BGPd, it should update…

### DIFF
--- a/bgpd/bgp_nexthop.c
+++ b/bgpd/bgp_nexthop.c
@@ -251,6 +251,26 @@ static void bgp_address_del(struct bgp *bgp, struct prefix *p)
 	}
 }
 
+/* Verify if the bgp router ID is in the address hash table */
+void bgp_validate_set_router_id(struct bgp *bgp, struct in_addr *new_addr)
+{
+	struct bgp_addr tmp;
+	struct bgp_addr *addr;
+
+	if (!new_addr) {
+		zlog_err("%s : invalid router ID", __func__);
+		return;
+	}
+
+	tmp.addr = bgp->router_id;
+	addr = hash_lookup(bgp->address_hash, &tmp);
+	if (addr == NULL) {
+		if (BGP_DEBUG(zebra, ZEBRA))
+			zlog_debug("RID change : vrf %d, RTR ID %s",
+				bgp->vrf_id, inet_ntoa(*new_addr));
+		bgp_router_id_set(bgp, new_addr);
+	}
+}
 
 struct bgp_connected_ref {
 	unsigned int refcnt;

--- a/bgpd/bgp_nexthop.h
+++ b/bgpd/bgp_nexthop.h
@@ -102,5 +102,6 @@ extern void bgp_tip_add(struct bgp *bgp, struct in_addr *tip);
 extern void bgp_tip_del(struct bgp *bgp, struct in_addr *tip);
 extern void bgp_tip_hash_init(struct bgp *bgp);
 extern void bgp_tip_hash_destroy(struct bgp *bgp);
-
+extern void bgp_validate_set_router_id(struct bgp *bgp,
+			struct in_addr *new_addr);
 #endif /* _QUAGGA_BGP_NEXTHOP_H */

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -1868,5 +1868,5 @@ extern void bgp_update_redist_vrf_bitmaps(struct bgp *, vrf_id_t);
 
 /* For benefit of rfapi */
 extern struct peer *peer_new(struct bgp *bgp);
-
+extern int bgp_router_id_set(struct bgp *bgp, const struct in_addr *id);
 #endif /* _QUAGGA_BGPD_H */


### PR DESCRIPTION
… the Router ID

in Next Restart only. #2865

When ZEBRA_ROUTER_ID_UPDATE is received from RIB, check if the current router ID
is valid (the IP address exists in bgp address hash table). If valid do not
update bgp router ID. This will prevent flapping of bgp session due to change
in router ID

Signed-off-by: kssoman <somanks@vmware.com>